### PR TITLE
Add multiple parameters (input, output, ...) + Java compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Add the following snippet to your pom.
 
 ```xml
-<plugin>
+<plugins>
   <plugin>
     <groupId>net.catte</groupId>
     <artifactId>scalapb-maven-plugin</artifactId>
-    <version>${project.version}</version>
+    <version>${scalapb-maven-plugin.version}</version>
     <executions>
       <execution>
         <goals>
@@ -17,5 +17,55 @@ Add the following snippet to your pom.
       </execution>
     </executions>
   </plugin>
-</plugin>
+</plugins>
+```
+
+### Configuration
+
+| Maven property       | Description                                | Default                                                 |
+| :------------------- | :----------------------------------------- | :------------------------------------------------------ |
+| `skip`               | `true` to skip protobuf compilation        | `false`                                                 |
+| `protocVersion`      | Protoc binary version                      | `v300`                                                  |
+| `inputDirectory`     | Input directory containing `*.proto` files | `${project.basedir}/src/main/protobuf`                  |
+| `includeDirectories` | Additional include directories (array)     | `[]`                                                    |
+| `outputDirectory`    | Output directory for Scala files           | `${project.build.directory}/generated-sources/protobuf` |
+| `flatPackage`        | `true` to flatten packages                 | `false`                                                 |
+
+For Java compatibility configuration, see the next section.
+
+### Java compatibility
+
+#### Configuration
+
+| Maven property        | Description                                        | Default                                                 |
+| :-------------------- | :------------------------------------------------- | :------------------------------------------------------ |
+| `javaOutput`          | `true` to also generate Java classes               | `false`                                                 |
+| `javaConversions`     | `true` to enable Java conversions in Scala classes | `false`                                                 |
+| `javaOutputDirectory` | Output directory for Java files                    | `${project.build.directory}/generated-sources/protobuf` |
+
+#### Usage
+
+To generate Java classes along with the Scala ones, use the following
+configuration.
+
+```xml
+<plugins>
+  <plugin>
+    <groupId>net.catte</groupId>
+    <artifactId>scalapb-maven-plugin</artifactId>
+    <version>${scalapb-maven-plugin.version}</version>
+    <configuration>
+      <javaOutput>true</javaOutput>
+      <javaConversions>true</javaConversions>
+    </configuration>
+    <executions>
+      <execution>
+        <goals>
+          <goal>compile</goal>
+        </goals>
+        <phase>generate-sources</phase>
+      </execution>
+    </executions>
+  </plugin>
+</plugins>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,11 @@
   <description>Maven plugin to compile Protobuf files in Scala using ScalaPB</description>
   <modules>
     <module>scalapb-maven-example</module>
+    <module>scalapb-maven-example-java</module>
     <module>scalapb-maven-plugin</module>
   </modules>
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <scala.version>2.11.12</scala.version>

--- a/scalapb-maven-example-java/pom.xml
+++ b/scalapb-maven-example-java/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>net.catte</groupId>
+    <artifactId>scalapb-maven</artifactId>
+    <version>1.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>scalapb-maven-example-java</artifactId>
+  <packaging>jar</packaging>
+  <name>ScalaPB Maven Plugin Example With Java Compatibility</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.catte</groupId>
+        <artifactId>scalapb-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <outputDirectory>${project.build.directory}/generated-sources/protobuf-scala</outputDirectory>
+          <javaConversions>true</javaConversions>
+          <javaOutput>true</javaOutput>
+          <javaOutputDirectory>${project.build.directory}/generated-sources/protobuf-java</javaOutputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/scalapb-maven-example-java/src/main/protobuf/addressbook.proto
+++ b/scalapb-maven-example-java/src/main/protobuf/addressbook.proto
@@ -1,0 +1,29 @@
+syntax = "proto2";
+
+package example;
+
+option java_package = "net.catte.scalapb.maven.example";
+option java_outer_classname = "AddressBookProtos";
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phones = 4;
+}
+
+message AddressBook {
+  repeated Person people = 1;
+}

--- a/scalapb-maven-plugin/pom.xml
+++ b/scalapb-maven-plugin/pom.xml
@@ -10,7 +10,7 @@
   <packaging>maven-plugin</packaging>
   <name>ScalaPB Maven Plugin</name>
   <properties>
-    <scalapb.version>0.6.7</scalapb.version>
+    <scalapb.version>0.7.4</scalapb.version>
   </properties>
   <dependencies>
     <dependency>
@@ -23,7 +23,7 @@
       <version>3.3.9</version>
     </dependency>
     <dependency>
-      <groupId>com.trueaccord.scalapb</groupId>
+      <groupId>com.thesamet.scalapb</groupId>
       <artifactId>scalapbc_${scala.version.short}</artifactId>
       <version>${scalapb.version}</version>
     </dependency>

--- a/scalapb-maven-plugin/src/main/java/net/catte/scalapb/maven/plugin/CompileMojo.java
+++ b/scalapb-maven-plugin/src/main/java/net/catte/scalapb/maven/plugin/CompileMojo.java
@@ -1,14 +1,18 @@
 package net.catte.scalapb.maven.plugin;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 @Mojo(name = "compile")
 public class CompileMojo extends AbstractMojo {
@@ -19,24 +23,125 @@ public class CompileMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean skip;
 
+    /**
+     * Protoc version.
+     * Defaults to v3.0.0
+     *
+     * @parameter property="protocVersion"
+     */
+    @Parameter(defaultValue = "v300")
+    private String protocVersion;
+
+    /**
+     * Input directory containing *.proto files.
+     * Defaults to <code>${project.basedir}/src/main/protobuf</code>.
+     *
+     * @parameter property="inputDirectory"
+     */
+    @Parameter(defaultValue = "${project.basedir}/src/main/protobuf")
+    private File inputDirectory;
+
+    /**
+     * Additional include directories.
+     *
+     * @parameter property="includeDirectories"
+     */
+    @Parameter
+    private File[] includeDirectories;
+
+    /**
+     * Output directory for Scala generated classes.
+     * Defaults to <code>${project.build.directory}/generated-sources/protobuf</code>.
+     *
+     * @parameter property="outputDirectory"
+     */
+    @Parameter(defaultValue = "${project.build.directory}/generated-sources/protobuf")
+    private File outputDirectory;
+
+    /**
+     * Set to true if output packages need to be flatten.
+     * Defaults to <code>false</code>.
+     *
+     * @parameter property="flatPackage"
+     */
+    @Parameter(defaultValue = "false")
+    private boolean flatPackage;
+
+    /**
+     * Set to true if Java classes also need to be generated.
+     * Defaults to <code>false</code>.
+     *
+     * @parameter property="javaOutput"
+     */
+    @Parameter(defaultValue = "false")
+    private boolean javaOutput;
+
+    /**
+     * Set to true if Java conversions are needed.
+     * Defaults to <code>false</code>.
+     *
+     * @parameter property="javaConversions"
+     */
+    @Parameter(defaultValue = "false")
+    private boolean javaConversions;
+
+    /**
+     * Output directory for Java generated classes.
+     * Defaults to <code>${project.build.directory}/generated-sources/protobuf</code>.
+     *
+     * @parameter property="javaOutputDirectory"
+     */
+    @Parameter(defaultValue = "${project.build.directory}/generated-sources/protobuf")
+    private File javaOutputDirectory;
+
     public void execute() throws MojoExecutionException {
         if (skip) {
             getLog().info("Skip flag set, skipping protobuf compilation.");
             return;
         }
 
-        String baseDir = project.getBasedir().getPath();
-        String buildDir = project.getBuild().getOutputDirectory();
-
-        Path protoPath= Paths.get(baseDir, "src", "main", "protobuf");
+        Path protoPath = Paths.get(inputDirectory.toURI());
         getLog().info("Reading proto files in '" + protoPath +"'.");
-        Path scalaOut = Paths.get(buildDir, "generated-sources","protobuf");
-        getLog().info("Writing Scala files in '" + scalaOut +"'.");
-        project.addCompileSourceRoot(scalaOut.toString());
+
+        Path[] includeDirectoriesPaths = ArrayUtils.toArray();
+        if(includeDirectories != null) {
+          includeDirectoriesPaths = Arrays.stream(includeDirectories).map(f -> {
+            getLog().info("Including proto files from '" + protoPath +"'.");
+            return Paths.get(f.toURI());
+          }).toArray(Path[]::new);
+        }
+
+        Path scalaOutPath = Paths.get(outputDirectory.toURI());
+        getLog().info("Writing Scala files in '" + scalaOutPath +"'.");
+        project.addCompileSourceRoot(scalaOutPath.toString());
+
+        Path javaOutPath = null;
+        if(javaOutput) {
+          javaOutPath = Paths.get(javaOutputDirectory.toURI());
+          getLog().info("Writing Java files in '" + javaOutPath +"'.");
+          project.addCompileSourceRoot(javaOutPath.toString());
+        }
 
         try {
-            Files.createDirectories(scalaOut);
-            ProtoCompiler.compile(protoPath, scalaOut);
+          Files.createDirectories(scalaOutPath);
+          if(javaOutput && javaOutPath != null) {
+            Files.createDirectories(javaOutPath);
+          }
+        } catch (IOException ioe) {
+          throw new MojoExecutionException("Error creating output directories", ioe);
+        }
+
+        try {
+            ProtoCompiler.compile(
+              protocVersion,
+              protoPath,
+              includeDirectoriesPaths,
+              scalaOutPath,
+              flatPackage,
+              javaConversions,
+              javaOutput,
+              javaOutPath
+            );
         } catch (Exception e) {
             throw new MojoExecutionException("Error compiling protobuf files", e);
         }

--- a/scalapb-maven-plugin/src/main/java/net/catte/scalapb/maven/plugin/CompileMojo.java
+++ b/scalapb-maven-plugin/src/main/java/net/catte/scalapb/maven/plugin/CompileMojo.java
@@ -104,7 +104,7 @@ public class CompileMojo extends AbstractMojo {
         getLog().info("Reading proto files in '" + protoPath +"'.");
 
         Path[] includeDirectoriesPaths = ArrayUtils.toArray();
-        if(includeDirectories != null) {
+        if (includeDirectories != null) {
           includeDirectoriesPaths = Arrays.stream(includeDirectories).map(f -> {
             getLog().info("Including proto files from '" + protoPath +"'.");
             return Paths.get(f.toURI());
@@ -116,7 +116,7 @@ public class CompileMojo extends AbstractMojo {
         project.addCompileSourceRoot(scalaOutPath.toString());
 
         Path javaOutPath = null;
-        if(javaOutput) {
+        if (javaOutput) {
           javaOutPath = Paths.get(javaOutputDirectory.toURI());
           getLog().info("Writing Java files in '" + javaOutPath +"'.");
           project.addCompileSourceRoot(javaOutPath.toString());
@@ -124,7 +124,7 @@ public class CompileMojo extends AbstractMojo {
 
         try {
           Files.createDirectories(scalaOutPath);
-          if(javaOutput && javaOutPath != null) {
+          if (javaOutput && javaOutPath != null) {
             Files.createDirectories(javaOutPath);
           }
         } catch (IOException ioe) {

--- a/scalapb-maven-plugin/src/main/scala/net/catte/scalapb/maven/plugin/ProtoCompiler.scala
+++ b/scalapb-maven-plugin/src/main/scala/net/catte/scalapb/maven/plugin/ProtoCompiler.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 import java.util.StringJoiner
 
+import scala.collection.mutable.ArrayBuffer
 import scala.util.matching.Regex
 import scalapb.ScalaPBC
 
@@ -17,6 +18,16 @@ object ProtoCompiler {
     good ++ these.filter(_.isDirectory).flatMap(recursiveListPaths(_,r))
   }
 
+  private def recursiveListProtoFilesInInputDirectoryPath(path: Path): Array[Path] = {
+    val file: File = new File(path.toUri)
+
+    if(!file.exists()) {
+      throw new IllegalArgumentException(s"inputDirectoryPath ($path) does not exist")
+    }
+
+    recursiveListPaths(file, ".*\\.proto".r)
+  }
+
   def compile(protocVersion: String,
               inputDirectoryPath: Path,
               includeDirectoriesPaths: Array[Path],
@@ -25,19 +36,21 @@ object ProtoCompiler {
               javaConversions: Boolean,
               javaOutput: Boolean,
               javaOutputPath: Path): Unit = {
-    val protoPathFile: File = new File(inputDirectoryPath.toUri)
+    val files: Array[Path] = recursiveListProtoFilesInInputDirectoryPath(inputDirectoryPath)
 
-    val files: Array[Path] = recursiveListPaths(protoPathFile, ".*\\.proto".r)
+    if (files.isEmpty) {
+      throw new IllegalArgumentException(s"$inputDirectoryPath does not contain .proto files")
+    }
 
     val protoPathsArgs: Array[String] = (inputDirectoryPath +: includeDirectoriesPaths).map {
       path => "--proto_path=" + path
     }
 
     val scalaOutOptionsJoiner = new StringJoiner(",")
-    if(flatPackage) {
+    if (flatPackage) {
       scalaOutOptionsJoiner.add("flat_package")
     }
-    if(javaConversions) {
+    if (javaOutput && javaConversions) {
       scalaOutOptionsJoiner.add("java_conversions")
     }
 
@@ -45,19 +58,21 @@ object ProtoCompiler {
 
     val scalaOutArgs = s"$scalaOutOptions:$outputDirectoryPath"
 
-    val javaArgs = if(javaOutput) {
+    val javaArgs = if (javaOutput) {
       Array(s"--java_out=$javaOutputPath")
     } else {
       Array.empty[String]
     }
 
-    val args = Array[String](s"-$protocVersion", "--throw") ++
-      protoPathsArgs ++
-      javaArgs ++
-      (
-        s"--scala_out=$scalaOutArgs" +:
-        files.map(_.toString)
-      )
+    val argsBuilder = new ArrayBuffer[String]()
+    argsBuilder.append(s"-$protocVersion")
+    argsBuilder.append("--throw")
+    argsBuilder.append(protoPathsArgs: _*)
+    argsBuilder.append(javaArgs: _*)
+    argsBuilder.append(s"--scala_out=$scalaOutArgs")
+    argsBuilder.append(files.map(_.toString): _*)
+
+    val args = argsBuilder.toArray
 
     ScalaPBC.main(args)
   }

--- a/scalapb-maven-plugin/src/main/scala/net/catte/scalapb/maven/plugin/ProtoCompiler.scala
+++ b/scalapb-maven-plugin/src/main/scala/net/catte/scalapb/maven/plugin/ProtoCompiler.scala
@@ -1,22 +1,63 @@
 package net.catte.scalapb.maven.plugin
 
-import java.nio.file.{Files, Path}
+import java.io.File
+import java.nio.file.{Path, Paths}
+import java.util.StringJoiner
 
-import com.trueaccord.scalapb.ScalaPBC
-
-import scala.collection.JavaConverters._
+import scala.util.matching.Regex
+import scalapb.ScalaPBC
 
 object ProtoCompiler {
 
-  def compile(protoPath: Path, scalaOut: Path): Unit = {
+  private def recursiveListPaths(f: File, r: Regex): Array[Path] = {
+    val these = f.listFiles
+    val good = these
+      .filter(f => r.findFirstIn(f.getName).isDefined)
+      .map(file => Paths.get(file.toURI))
+    good ++ these.filter(_.isDirectory).flatMap(recursiveListPaths(_,r))
+  }
 
-    val files: Array[String] = Files.list(protoPath).iterator().asScala.map(_.toString).toArray
+  def compile(protocVersion: String,
+              inputDirectoryPath: Path,
+              includeDirectoriesPaths: Array[Path],
+              outputDirectoryPath: Path,
+              flatPackage: Boolean,
+              javaConversions: Boolean,
+              javaOutput: Boolean,
+              javaOutputPath: Path): Unit = {
+    val protoPathFile: File = new File(inputDirectoryPath.toUri)
 
-    val args: Array[String] = Array[String](
-      "-v300",
-      "--throw",
-      s"--proto_path=$protoPath",
-      s"--scala_out=$scalaOut") ++ files
+    val files: Array[Path] = recursiveListPaths(protoPathFile, ".*\\.proto".r)
+
+    val protoPathsArgs: Array[String] = (inputDirectoryPath +: includeDirectoriesPaths).map {
+      path => "--proto_path=" + path
+    }
+
+    val scalaOutOptionsJoiner = new StringJoiner(",")
+    if(flatPackage) {
+      scalaOutOptionsJoiner.add("flat_package")
+    }
+    if(javaConversions) {
+      scalaOutOptionsJoiner.add("java_conversions")
+    }
+
+    val scalaOutOptions = scalaOutOptionsJoiner.toString
+
+    val scalaOutArgs = s"$scalaOutOptions:$outputDirectoryPath"
+
+    val javaArgs = if(javaOutput) {
+      Array(s"--java_out=$javaOutputPath")
+    } else {
+      Array.empty[String]
+    }
+
+    val args = Array[String](s"-$protocVersion", "--throw") ++
+      protoPathsArgs ++
+      javaArgs ++
+      (
+        s"--scala_out=$scalaOutArgs" +:
+        files.map(_.toString)
+      )
 
     ScalaPBC.main(args)
   }


### PR DESCRIPTION
Hello,

I have just made some changes to the plugin, mostly to make it more configurable. I have added the following parameters for Scala configuration : `protocVersion`, `inputDirectory`, `includeDirectories`, `outputDirectory` and `flatPackage`. The other parameters : `javaOutput`, `javaConversions` and `javaOutputDirectory` are used for Java compatibility. It allows ScalaPB to create Java classes.

I updated the documentation with these parameters (and their default values), and an example : see `README.md`.

I have also updated the Java version (Java 7 -> Java 8), and the ScalaPB plugin to the latest release (`com.trueaccord.scalapb:scalapbc_2.11:0.6.7` -> `com.thesamet.scalapb:scalapbc_2.11:0.7.4`).