### PR TITLE
Remove useless maven-javadoc-plugin in scalapb-maven-example-java

### DIFF
--- a/scalapb-maven-example-java/pom.xml
+++ b/scalapb-maven-example-java/pom.xml
@@ -37,18 +37,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Hi,

I'm coming with a bunch of PRs :smile: 

This one removes the `maven-javadoc-plugin` from `scalapb-maven-example-java` because it's not necessary to demonstrate the usage of the plugin.

Moreover, since the version of the plugin was missing, the modification solves the following build warning:

```                                                                                                                                                                                                                               
[WARNING] Some problems were encountered while building the effective model for net.catte:scalapb-maven-example-java:jar:1.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ net.catte:scalapb-maven-example-java:[unknown-version], /path/to/scalapb-maven/scalapb-maven-example-java/pom.xml, line 40, column 15
```