### PR TITLE
Option to add proto sources as resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Add the following snippet to your pom.
 
 ### Configuration
 
-| Maven property       | Description                                | Default                                                 |
-| :------------------- | :----------------------------------------- | :------------------------------------------------------ |
-| `skip`               | `true` to skip protobuf compilation        | `false`                                                 |
-| `protocVersion`      | Protoc binary version                      | `v300`                                                  |
-| `inputDirectory`     | Input directory containing `*.proto` files | `${project.basedir}/src/main/protobuf`                  |
-| `includeDirectories` | Additional include directories (array)     | `[]`                                                    |
-| `outputDirectory`    | Output directory for Scala files           | `${project.build.directory}/generated-sources/protobuf` |
-| `flatPackage`        | `true` to flatten packages                 | `false`                                                 |
+| Maven property       | Description                                        | Default                                                 |
+| :------------------- | :------------------------------------------------- | :------------------------------------------------------ |
+| `skip`               | `true` to skip protobuf compilation                | `false`                                                 |
+| `protocVersion`      | Protoc binary version                              | `v300`                                                  |
+| `inputDirectory`     | Input directory containing `*.proto` files         | `${project.basedir}/src/main/protobuf`                  |
+| `includeDirectories` | Additional include directories (array)             | `[]`                                                    |
+| `addProtoSources`    | `true` to add proto files (`*.proto`) as resources | `false`                                                    |
+| `outputDirectory`    | Output directory for Scala files                   | `${project.build.directory}/generated-sources/protobuf` |
+| `flatPackage`        | `true` to flatten packages                         | `false`                                                 |
 
 For Java compatibility configuration, see the next section.
 

--- a/scalapb-maven-example/pom.xml
+++ b/scalapb-maven-example/pom.xml
@@ -15,6 +15,9 @@
         <groupId>net.catte</groupId>
         <artifactId>scalapb-maven-plugin</artifactId>
         <version>${project.version}</version>
+        <configuration>
+          <addProtoSources>true</addProtoSources>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/scalapb-maven-plugin/src/main/java/net/catte/scalapb/maven/plugin/CompileMojo.java
+++ b/scalapb-maven-plugin/src/main/java/net/catte/scalapb/maven/plugin/CompileMojo.java
@@ -3,9 +3,11 @@ package net.catte.scalapb.maven.plugin;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,12 +15,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 
 @Mojo(name = "compile")
 public class CompileMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}")
     private MavenProject project;
+
+    @Component
+    private MavenProjectHelper projectHelper;
 
     @Parameter(defaultValue = "false")
     private boolean skip;
@@ -48,6 +54,15 @@ public class CompileMojo extends AbstractMojo {
      */
     @Parameter
     private File[] includeDirectories;
+
+    /**
+     * Add proto sources as resources.
+     * Defaults to <code>false</code>.
+     *
+     * @parameter property="addProtoSources"
+     */
+    @Parameter(defaultValue = "false")
+    private boolean addProtoSources;
 
     /**
      * Output directory for Scala generated classes.
@@ -114,6 +129,15 @@ public class CompileMojo extends AbstractMojo {
         Path scalaOutPath = Paths.get(outputDirectory.toURI());
         getLog().info("Writing Scala files in '" + scalaOutPath +"'.");
         project.addCompileSourceRoot(scalaOutPath.toString());
+
+        if (addProtoSources) {
+          projectHelper.addResource(
+            project,
+            inputDirectory.getAbsolutePath(),
+            Collections.singletonList("**/*.proto"),
+            Collections.emptyList()
+          );
+        }
 
         Path javaOutPath = null;
         if (javaOutput) {


### PR DESCRIPTION
Hi,

Just added an option to add proto files (`**/*.proto`) as resources, because it's sometimes convenient to have proto files in generated JARs.

This is just a port of what's done on [`protoc-jar-maven-plugin`](https://github.com/os72/protoc-jar-maven-plugin) for Java (see the [documentation of `addProtoSources`](http://os72.github.io/protoc-jar-maven-plugin/run-mojo.html#addProtoSources)).

I've also updated the documentation with this new parameter.