### PR TITLE
Add compiled sources in JAR in scalapb-maven-example

### DIFF
--- a/scalapb-maven-example/pom.xml
+++ b/scalapb-maven-example/pom.xml
@@ -10,19 +10,12 @@
   <packaging>jar</packaging>
   <name>ScalaPB Maven Plugin Example</name>
   <properties>
-    <scala.major.minor.version>2.11</scala.major.minor.version>
-    <scala.version>2.11.8</scala.version>
     <scalapb.version>0.7.4</scalapb.version>
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.thesamet.scalapb</groupId>
-      <artifactId>scalapb-runtime_${scala.major.minor.version}</artifactId>
+      <artifactId>scalapb-runtime_${scala.version.short}</artifactId>
       <version>${scalapb.version}</version>
     </dependency>
   </dependencies>

--- a/scalapb-maven-example/pom.xml
+++ b/scalapb-maven-example/pom.xml
@@ -9,8 +9,47 @@
   <artifactId>scalapb-maven-example</artifactId>
   <packaging>jar</packaging>
   <name>ScalaPB Maven Plugin Example</name>
+  <properties>
+    <scala.major.minor.version>2.11</scala.major.minor.version>
+    <scala.version>2.11.8</scala.version>
+    <scalapb.version>0.7.4</scalapb.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.thesamet.scalapb</groupId>
+      <artifactId>scalapb-runtime_${scala.major.minor.version}</artifactId>
+      <version>${scalapb.version}</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+            <goals>
+              <goal>add-source</goal>
+              <goal>compile</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>net.catte</groupId>
         <artifactId>scalapb-maven-plugin</artifactId>


### PR DESCRIPTION
Hi,

I've noticed that the `scalapb-maven-example` did not compile generated sources, so the JAR generated during `package` phase is empty:

```
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ scalapb-maven-example ---
[WARNING] JAR will be empty - no content was marked for inclusion!
```

I've updated the example to make a complete example of using the plugin (not just generating Scala sources, but **also compiling them**). This will help beginners to use the plugin I think.